### PR TITLE
#4 Events: EventEmitter

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@
 /out
 /include
 *.tsbuildinfo
+*.toml
+*.tgz

--- a/package.json
+++ b/package.json
@@ -1,12 +1,11 @@
 {
-  "name": "@rbxts/Tina",
+  "name": "@rbxts/tina",
   "version": "1.0.0",
   "description": "",
   "main": "out/init.lua",
   "scripts": {
     "build": "rbxtsc",
-    "watch": "rbxtsc -w",
-    "prepublishOnly": "npm run build"
+    "watch": "rbxtsc -w"
   },
   "keywords": [],
   "author": "",

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,4 @@
 import { Manifest } from "./lib/types/manifest";
-import { NetworkConfig } from "./lib/types/network";
 
 export enum Protocol {
 	/** Create/Load Online User Data */
@@ -8,9 +7,7 @@ export enum Protocol {
 	NET = "NET",
 }
 
-interface DefaultUserData {
-
-}
+interface DefaultUserData {}
 
 namespace Tina {
 	export function registerGame(name: string, manifest: Manifest) {
@@ -18,51 +15,37 @@ namespace Tina {
 	}
 
 	export class TinaGame {
-		core() {
-
-		}
+		core() {}
 	}
 
 	export namespace Mirror {
 		export class User {
-			constructor(id: number) {
-			}
+			constructor(id: number) {}
 
 			static fromPlayer(plr: Player) {
 				return new User(plr.UserId);
 			}
 
-			load() {
+			load() {}
 
-			}
-
-			unload() {
-
-			}
+			unload() {}
 		}
 	}
 
 	export namespace Net {
-		class Endpoint {
+		class Endpoint {}
 
-		}
-
-		export class NetworkProtocol {
-
-		}
+		export class NetworkProtocol {}
 
 		export function protocol(protocol: Protocol, tree?: unknown): NetworkProtocol {
 			return new NetworkProtocol();
 		}
 
-		export function registerNetwork(tree: { [key: string]: NetworkProtocol }) {
+		export function registerNetwork(tree: { [key: string]: NetworkProtocol }) {}
 
-		}
-
-		export function endpoint<T>() {
-
-		}
+		export function endpoint<T>() {}
 	}
 }
 
 export default Tina;
+export { EventEmitter } from "./lib/events/event_emitter";

--- a/src/lib/events/event_emitter.ts
+++ b/src/lib/events/event_emitter.ts
@@ -1,0 +1,43 @@
+import { IBaseEvents, TEventToken, TInferParameters, TInferReturn } from "../types/events";
+
+class EventListener<T> {
+	private readonly listeners: Array<Callback> = new Array();
+
+	public do<X extends TInferReturn<T>>(handler: (...args: TInferParameters<T>) => X): EventListener<X> {
+		this.listeners.push(handler);
+
+		return this as unknown as EventListener<X>;
+	}
+
+	public call<T extends unknown[]>(...args: T) {
+		let lastCallReturn: unknown[] | undefined;
+
+		for (const handler of this.listeners) {
+			lastCallReturn = handler(...(lastCallReturn !== undefined ? lastCallReturn : args));
+		}
+	}
+}
+
+export abstract class EventEmitter<Events extends IBaseEvents = {}> {
+	private readonly events: Map<TEventToken<Events>, EventListener<Events[TEventToken<Events>]>> = new Map();
+
+	protected when<T extends TEventToken<Events>>(token: T): EventListener<Events[T]> {
+		const hasEvent = this.events.has(token);
+		let event!: EventListener<Events[T]>;
+
+		if (!hasEvent) {
+			const eventListener = new EventListener<Events[T]>();
+			this.events.set(token, eventListener);
+
+			event = eventListener;
+		} else event = this.events.get(token) as EventListener<Events[T]>;
+
+		return event;
+	}
+
+	protected async emit<T extends TEventToken<Events>>(token: T, ...args: TInferParameters<Events[T]>): Promise<void> {
+		const event = this.events.get(token);
+
+		if (event !== undefined) event.call(...args);
+	}
+}

--- a/src/lib/types/events.d.ts
+++ b/src/lib/types/events.d.ts
@@ -1,0 +1,6 @@
+export type TEventToken<T> = Extract<keyof T, string | symbol>;
+
+export type TInferParameters<T> = T extends (...args: infer P) => unknown ? P : unknown[];
+export type TInferReturn<T> = T extends (...args: never) => infer R ? R : void;
+
+export interface IBaseEvents {}


### PR DESCRIPTION
Some of the methods that are available for the EventEmitter:

`.when(token: string) => EventListener`
`.emit(token: string, ...args: unknown[]) => void`

And the methods that are available for the EventListener:

`.do<X>(callback: (...args: T) => X) => EventListener<X>` Returns the same EventListener but with the returning value of the callback, which is then used as the argument of the next binded function. 
(internal) `.call(...args: unknown[]) => void`

An example of the API:
```typescript
export class Service extends EventEmitter<{ playerJoined: (plr: Player) => void }> {
    constructor() {
        this.when("playerJoined")
           .do((plr: Player) => {
               return "hello!"
           })
           .do((value: string) => print("value");


        this.emit("playerJoined", playerObject);
    }
}
```