### PR TITLE
fix(ecs): query entering and exiting

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rbxts/tina",
-  "version": "0.0.2",
+  "version": "0.0.5",
   "description": "",
   "main": "out/init.lua",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rbxts/tina",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "",
   "main": "out/init.lua",
   "scripts": {

--- a/src/lib/ecs/collections/sparse-set.ts
+++ b/src/lib/ecs/collections/sparse-set.ts
@@ -10,7 +10,6 @@ export class SparseSet {
 	/** The elements stored in the sparse set. */
 	public dense: Array<number> = [];
 	/** An array that maps the set's items to their indices in the dense. */
-	// TODO: Should this be preallocated to the universe size?
 	public sparse: Array<number> = [];
 
 	/**

--- a/src/lib/ecs/query.spec.ts
+++ b/src/lib/ecs/query.spec.ts
@@ -154,6 +154,33 @@ export = (): void => {
 				expect(callCount).to.equal(1);
 			});
 
+			it("allow for multiple entities to enter the query", () => {
+				internal_resetGlobalState();
+				const tempWorld = new World();
+
+				const component = ComponentInternalCreation.createComponent({
+					componentData: [],
+				});
+
+				const id1 = tempWorld.add();
+				const id2 = tempWorld.add();
+
+				const query = tempWorld.createQuery(ALL(component));
+
+				tempWorld.addComponent(id1, component);
+				tempWorld.addComponent(id2, component);
+
+				tempWorld.flush();
+
+				let callCount = 0;
+
+				query.enteredQuery((entityId) => {
+					callCount += 1;
+				});
+
+				expect(callCount).to.equal(2);
+			});
+
 			it("not be present on next iteration of query", () => {
 				internal_resetGlobalState();
 				const tempWorld = new World();
@@ -217,6 +244,38 @@ export = (): void => {
 				});
 
 				expect(callCount).to.equal(10);
+			});
+
+			it("allow for multiple entities to exit the query", () => {
+				internal_resetGlobalState();
+				const tempWorld = new World();
+
+				const component = ComponentInternalCreation.createComponent({
+					componentData: [],
+				});
+
+				const id1 = tempWorld.add();
+				const id2 = tempWorld.add();
+
+				const query = tempWorld.createQuery(ALL(component));
+
+				tempWorld.addComponent(id1, component);
+				tempWorld.addComponent(id2, component);
+
+				tempWorld.flush();
+
+				tempWorld.removeComponent(id1, component);
+				tempWorld.removeComponent(id2, component);
+
+				tempWorld.flush();
+
+				let callCount = 0;
+
+				query.exitedQuery((entityId) => {
+					callCount += 1;
+				});
+
+				expect(callCount).to.equal(2);
 			});
 
 			it("not be present on next iteration of query", () => {

--- a/src/lib/ecs/query.ts
+++ b/src/lib/ecs/query.ts
@@ -183,7 +183,7 @@ export class Query {
 	 */
 	public enteredQuery(callback: (entityId: EntityId) => boolean | void): void {
 		for (const entityId of this.entered.dense) {
-			if (!callback(entityId)) {
+			if (callback(entityId) === false) {
 				break;
 			}
 		}
@@ -209,7 +209,7 @@ export class Query {
 	 */
 	public exitedQuery(callback: (entityId: EntityId) => boolean | void): void {
 		for (const entityId of this.exited.dense) {
-			if (!callback(entityId)) {
+			if (callback(entityId) === false) {
 				break;
 			}
 		}
@@ -235,7 +235,7 @@ export class Query {
 	public forEach(callback: (entityId: EntityId) => boolean | void): void {
 		for (const archetype of this.archetypes) {
 			for (const entityId of archetype.entities) {
-				if (!callback(entityId)) {
+				if (callback(entityId) === false) {
 					return;
 				}
 			}

--- a/src/lib/ecs/world.ts
+++ b/src/lib/ecs/world.ts
@@ -627,8 +627,6 @@ export class World {
 			query.entered.add(entityId);
 		}
 
-		print(newArchetype.queries);
-
 		this.entityManager.updateTo[entityId] = newArchetype;
 	}
 

--- a/src/lib/ecs/world.ts
+++ b/src/lib/ecs/world.ts
@@ -109,29 +109,25 @@ export class World {
 		data?: Partial<OptionalKeys<GetComponentSchema<C>>>,
 	): this {
 		if (!this.has(entityId)) {
-			throw error(`Entity ${entityId} does not exist in world ${tostring(this)}`);
+			throw `Entity ${entityId} does not exist in world ${tostring(this)}`;
 		}
 
 		this.componentsToUpdate.add(entityId);
 
 		debug.profilebegin("World:addComponent");
 		{
-			const componentId = (component as unknown as AnyComponentInternal).componentId;
+			const componentId = (component as AnyComponentInternal).componentId;
 			if (
 				!this.hasComponentInternal(this.entityManager.updateTo[entityId].mask, componentId)
 			) {
-				this.entityManager.updateTo[entityId] = this.archetypeChange(
-					this.entityManager.updateTo[entityId],
-					componentId,
-					entityId,
-				);
+				this.updateArchetype(entityId, componentId);
+
+				if (data !== undefined) {
+					component.set(entityId, data);
+				}
 			}
 		}
 		debug.profileend();
-
-		if (data !== undefined) {
-			component.set(entityId, data);
-		}
 
 		return this;
 	}
@@ -333,7 +329,7 @@ export class World {
 	 * @returns true if the entity has the given component.
 	 */
 	public hasComponent(entityId: EntityId, component: AnyComponent): boolean {
-		const componentId = (component as unknown as AnyComponentInternal).componentId;
+		const componentId = (component as AnyComponentInternal).componentId;
 		return this.hasComponentInternal(this.entityManager.entities[entityId].mask, componentId);
 	}
 
@@ -410,22 +406,18 @@ export class World {
 	 */
 	public removeComponent(entityId: EntityId, component: AnyComponent): this {
 		if (!this.has(entityId)) {
-			throw error(`Entity ${entityId} does not exist in world ${tostring(this)}`);
+			throw `Entity ${entityId} does not exist in world ${tostring(this)}`;
 		}
 
 		this.componentsToUpdate.add(entityId);
 
 		debug.profilebegin("World:removeComponent");
 		{
-			const componentId = (component as unknown as AnyComponentInternal).componentId;
+			const componentId = (component as AnyComponentInternal).componentId;
 			if (
 				this.hasComponentInternal(this.entityManager.updateTo[entityId].mask, componentId)
 			) {
-				this.entityManager.updateTo[entityId] = this.archetypeChange(
-					this.entityManager.updateTo[entityId],
-					componentId,
-					entityId,
-				);
+				this.updateArchetype(entityId, componentId);
 			}
 		}
 		debug.profileend();
@@ -566,26 +558,10 @@ export class World {
 	 *
 	 * @returns
 	 */
-	private archetypeChange(
-		arch: Archetype,
-		componentId: ComponentId,
-		entityId: EntityId,
-	): Archetype {
+	private archetypeChange(arch: Archetype, componentId: ComponentId): Archetype {
 		if (!arch.change[componentId]) {
 			arch.mask[~~(componentId / 32)] ^= 1 << componentId % 32;
-
-			arch.queries.forEach(query => {
-				query.entered.remove(entityId);
-				query.exited.add(entityId);
-			});
-
-			const newArchetype = this.getArchetype(arch.mask);
-			newArchetype.queries.forEach(query => {
-				query.exited.remove(entityId);
-				query.entered.add(entityId);
-			});
-
-			arch.change[componentId] = newArchetype;
+			arch.change[componentId] = this.getArchetype(arch.mask);
 			arch.mask[~~(componentId / 32)] ^= 1 << componentId % 32;
 		}
 
@@ -629,6 +605,31 @@ export class World {
 	 */
 	private hasComponentInternal(mask: Array<ComponentId>, componentId: number): boolean {
 		return (mask[~~(componentId / 32)] & (1 << componentId % 32)) >= 1;
+	}
+
+	/**
+	 * Transition an entity from one archetype to another, and update all
+	 * queries accordingly.
+	 *
+	 * @param entityId The id of the entity to transition.
+	 * @param componentId The id of the component to change.
+	 */
+	private updateArchetype(entityId: EntityId, componentId: ComponentId): void {
+		const oldArchetype = this.entityManager.updateTo[entityId];
+		for (const query of oldArchetype.queries) {
+			query.entered.remove(entityId);
+			query.exited.add(entityId);
+		}
+
+		const newArchetype = this.archetypeChange(oldArchetype, componentId);
+		for (const query of newArchetype.queries) {
+			query.exited.remove(entityId);
+			query.entered.add(entityId);
+		}
+
+		print(newArchetype.queries);
+
+		this.entityManager.updateTo[entityId] = newArchetype;
 	}
 
 	/**

--- a/studio.project.json
+++ b/studio.project.json
@@ -1,5 +1,5 @@
 {
-	"name": "tina-as-game",
+	"name": "tina-tests",
 	"globIgnorePaths": [
 		"**/package.json",
 		"**/tsconfig.json"


### PR DESCRIPTION

##### Description

Only the first entity could enter a query as we cached the archetype change for any component change beyond the first before a flush.
The iterator for the query would also break instantly if the query did not return true.
