### PR TITLE
refactor(ecs): remove `forEach`, rename `iterate` to `items`

### DIFF
--- a/src/lib/ecs/query.ts
+++ b/src/lib/ecs/query.ts
@@ -218,6 +218,20 @@ export class Query {
 	}
 
 	/**
+	 * Runs a callback for each entity that matches the query.
+	 *
+	 * TODO: This should be turned into a *[Symbol.iterator] method whenever
+	 * that is supported.
+	 */
+	public *iter(): Generator<EntityId> {
+		for (const archetype of this.archetypes) {
+			for (const entityId of archetype.entities) {
+				yield entityId;
+			}
+		}
+	}
+
+	/**
 	 * @returns an array of all matching entities mapped to their IDs.
 	 */
 	public items(): Array<EntityId> {

--- a/src/lib/ecs/query.ts
+++ b/src/lib/ecs/query.ts
@@ -218,42 +218,18 @@ export class Query {
 	}
 
 	/**
-	 * Runs a callback for each entity that matches the query.
-	 *
-	 * If the callback returns `false`, the iteration will stop, and no other
-	 * entities in this query will be iterated over.
-	 *
-	 * #### Usage Example:
-	 * ```ts
-	 * query.forEach((entity) => {
-	 * 	// ...
-	 * });
-	 * ```
-	 *
-	 * @param callback The callback to run for each entity.
+	 * @returns an array of all matching entities mapped to their IDs.
 	 */
-	public forEach(callback: (entityId: EntityId) => boolean | void): void {
-		for (const archetype of this.archetypes) {
-			for (const entityId of archetype.entities) {
-				if (callback(entityId) === false) {
-					return;
-				}
-			}
-		}
-	}
+	public items(): Array<EntityId> {
+		const idList: Array<EntityId> = new Array();
 
-	/**
-	 * Runs a callback for each entity that matches the query.
-	 *
-	 * TODO: This should be turned into a *[Symbol.iterator] method whenever
-	 * that is supported.
-	 */
-	public *iterate(): Generator<EntityId> {
 		for (const archetype of this.archetypes) {
 			for (const entityId of archetype.entities) {
-				yield entityId;
+				idList.push(entityId);
 			}
 		}
+
+		return idList;
 	}
 
 	/**


### PR DESCRIPTION
##### Description

Removes `Query#forEach` as proposed in #42. Also resolves #47 by renaming `Query#iterate` to `Query#items`.

##### Tasks

  - [x] Tests Modified
  - [x] Tests Passing

##### Documentation

  - [x] [Documentation]() written
  - [x] [Documentation](https://github.com/AetherInteractiveLtd/docs) submitted
  - [ ] [Documentation](https://github.com/AetherInteractiveLtd/docs) published

##### Linked

Resolves #42 <!-- OPTIONAL -->
Resolves #47 <!-- OPTIONAL -->
Resolves AetherInteractiveLtd/docs#2