### PR TITLE
Refactor!(ECS) - Remove forEach and add items()

### DIFF
--- a/src/lib/ecs/query.spec.ts
+++ b/src/lib/ecs/query.spec.ts
@@ -187,9 +187,9 @@ export = (): void => {
 
 				let callCount = 0;
 
-				query.enteredQuery((entityId) => {
+				for (const _entityId of query.enteredQuery()) {
 					callCount += 1;
-				});
+				};
 
 				expect(callCount).to.equal(1);
 			});
@@ -214,9 +214,10 @@ export = (): void => {
 
 				let callCount = 0;
 
-				query.enteredQuery((entityId) => {
+				for (const _entityId of query.enteredQuery()) {
 					callCount += 1;
-				});
+				};
+
 
 				expect(callCount).to.equal(2);
 			});
@@ -239,15 +240,15 @@ export = (): void => {
 
 				let callCount = 0;
 
-				query.enteredQuery((entityId) => {
+				for (const _entityId of query.enteredQuery()) {
 					callCount += 1;
-				});
+				};
 
 				expect(callCount).to.equal(1);
 
-				query.enteredQuery((entityId) => {
+				for (const _entityId of query.enteredQuery()) {
 					callCount += 1;
-				});
+				};
 
 				expect(callCount).to.equal(1);
 			});
@@ -275,13 +276,13 @@ export = (): void => {
 
 				// We need to ensure that the entity is not entered and exited
 				// at the same time
-				query.enteredQuery((entityId) => {
+				for (const _entityId of query.enteredQuery()) {
 					callCount += 1;
-				});
+				};
 
-				query.exitedQuery((entityId) => {
+				for (const _entityId of query.exitedQuery()) {
 					callCount += 10;
-				});
+				};
 
 				expect(callCount).to.equal(10);
 			});
@@ -311,9 +312,9 @@ export = (): void => {
 
 				let callCount = 0;
 
-				query.exitedQuery((entityId) => {
+				for (const _entityId of query.exitedQuery()) {
 					callCount += 1;
-				});
+				};
 
 				expect(callCount).to.equal(2);
 			});
@@ -337,15 +338,15 @@ export = (): void => {
 
 				let callCount = 0;
 
-				query.exitedQuery((entityId) => {
+				for (const _entityId of query.exitedQuery()) {
 					callCount += 1;
-				});
+				};
 
 				expect(callCount).to.equal(1);
 
-				query.exitedQuery((entityId) => {
+				for (const _entityId of query.exitedQuery()) {
 					callCount += 1;
-				});
+				};
 
 				expect(callCount).to.equal(1);
 			});

--- a/src/lib/ecs/query.spec.ts
+++ b/src/lib/ecs/query.spec.ts
@@ -168,6 +168,42 @@ export = (): void => {
 			});
 		});
 
+		describe("items", () => {
+			it("get all entities", () => {
+				internal_resetGlobalState();
+				const tempWorld = new World();
+
+				const component = ComponentInternalCreation.createComponent({
+					componentData: [],
+				});
+
+				const component1 = ComponentInternalCreation.createComponent({
+					componentData: [],
+				});
+
+				const id1 = tempWorld.add();
+				const id2 = tempWorld.add();
+				const id3 = tempWorld.add();
+				const id4 = tempWorld.add();
+				const id5 = tempWorld.add();
+
+				tempWorld.addComponent(id1, component);
+				tempWorld.addComponent(id2, component);
+				tempWorld.addComponent(id3, component).addComponent(id3, component1);
+				tempWorld.addComponent(id4, component).addComponent(id4, component1);
+				tempWorld.addComponent(id5, component1);
+
+				tempWorld.flush();
+
+				const query = tempWorld.createQuery(ALL(component));
+				const allEntities = query.items();
+
+				print(allEntities);
+
+				expect(allEntities.size()).to.equal(4);
+			});
+		});
+
 		describe("enteredQuery", () => {
 			it("allow for entities to enter the query", () => {
 				internal_resetGlobalState();
@@ -217,7 +253,6 @@ export = (): void => {
 				for (const _entityId of query.enteredQuery()) {
 					callCount += 1;
 				};
-
 
 				expect(callCount).to.equal(2);
 			});

--- a/src/lib/ecs/query.ts
+++ b/src/lib/ecs/query.ts
@@ -232,7 +232,7 @@ export class Query {
 	 * TODO: This should be turned into a *[Symbol.iterator] method whenever
 	 * that is supported.
 	 */
-	public *iterate(): Generator<EntityId> {
+	public *iter(): Generator<EntityId> {
 		for (const archetype of this.archetypes) {
 			for (const entityId of archetype.entities) {
 				yield entityId;

--- a/src/lib/ecs/query.ts
+++ b/src/lib/ecs/query.ts
@@ -104,9 +104,9 @@ export function NOT(components: RawQuery | AnyComponent | TagComponent): RawQuer
  *
  * const world = Tina.createWorld({...});
  * const query = world.createQuery(Position, ANY(Velocity, NOT(Acceleration)));
- * query.forEach((entity) => {
+ * for (const entity of query.iterate()) {
  * 	// ...
- * });
+ * };
  * ```
  *
  * @note Order of iteration is not guaranteed.
@@ -181,11 +181,9 @@ export class Query {
 	 *
 	 * @param callback The callback to run for each entity.
 	 */
-	public enteredQuery(callback: (entityId: EntityId) => boolean | void): void {
+	public *enteredQuery(): Generator<EntityId> {
 		for (const entityId of this.entered.dense) {
-			if (callback(entityId) === false) {
-				break;
-			}
+			yield entityId;
 		}
 
 		this.entered = new SparseSet();
@@ -207,39 +205,12 @@ export class Query {
 	 *
 	 * @param callback The callback to run for each entity.
 	 */
-	public exitedQuery(callback: (entityId: EntityId) => boolean | void): void {
+	public *exitedQuery(): Generator<EntityId> {
 		for (const entityId of this.exited.dense) {
-			if (callback(entityId) === false) {
-				break;
-			}
+			yield entityId;
 		}
 
 		this.exited = new SparseSet();
-	}
-
-	/**
-	 * Runs a callback for each entity that matches the query.
-	 *
-	 * If the callback returns `false`, the iteration will stop, and no other
-	 * entities in this query will be iterated over.
-	 *
-	 * #### Usage Example:
-	 * ```ts
-	 * query.forEach((entity) => {
-	 * 	// ...
-	 * });
-	 * ```
-	 *
-	 * @param callback The callback to run for each entity.
-	 */
-	public forEach(callback: (entityId: EntityId) => boolean | void): void {
-		for (const archetype of this.archetypes) {
-			for (const entityId of archetype.entities) {
-				if (callback(entityId) === false) {
-					return;
-				}
-			}
-		}
 	}
 
 	/**

--- a/src/lib/ecs/query.ts
+++ b/src/lib/ecs/query.ts
@@ -214,6 +214,19 @@ export class Query {
 	}
 
 	/**
+	 * @returns an array of all the entities that currently match the query.
+	 */
+	public items(): Array<EntityId> {
+		const newArray = table.clone(this.archetypes[0].entities);
+		for (const i of $range(1, this.archetypes.size() - 1)) {
+			const archetype = this.archetypes[i].entities;
+			archetype.move(0, archetype.size(), newArray.size(), newArray);
+		}
+
+		return newArray;
+	}
+
+	/**
 	 * Runs a callback for each entity that matches the query.
 	 *
 	 * TODO: This should be turned into a *[Symbol.iterator] method whenever


### PR DESCRIPTION
##### Description

Remove the forEach loop in favour of just using the iteration function to avoid the overhead of function calls for each entitiy. This is also done for queryEntered and queryExited.

Added an items() function to get all the entities in the query as a single array,

Resolves #42
Resolves #47