### PR TITLE
fix!(ecs): components allowed to be created late

### DIFF
--- a/src/lib/ecs/component.spec.ts
+++ b/src/lib/ecs/component.spec.ts
@@ -25,6 +25,16 @@ export = (): void => {
 			expect(component).to.be.ok();
 		});
 
+		it("not be able to be created after entities have been added", () => {
+			world.add();	
+
+			expect(() => {
+				ComponentInternalCreation.createComponent({
+					x: ComponentTypes.Number,
+				});
+			}).to.throw();
+		});
+
 		it("be able to be given to an entity", () => {
 			const component = ComponentInternalCreation.createComponent({
 				x: ComponentTypes.Number,
@@ -51,6 +61,11 @@ export = (): void => {
 			const component = ComponentInternalCreation.createComponent({
 				x: ComponentTypes.Number,
 			});
+			
+			const component2 = ComponentInternalCreation.createComponent({
+				x: ComponentTypes.Number,
+			});
+
 			const entity = world.add();
 			world.addComponent(entity, component);
 			world.flush();
@@ -59,9 +74,6 @@ export = (): void => {
 			});
 			expect((component as ComponentInternal<{ x: Array<number> }>).x[entity]).to.equal(1);
 
-			const component2 = ComponentInternalCreation.createComponent({
-				x: ComponentTypes.Number,
-			});
 			const entity2 = world.add();
 			world.addComponent(entity2, component2, {
 				x: 2,

--- a/src/lib/ecs/component.ts
+++ b/src/lib/ecs/component.ts
@@ -3,7 +3,7 @@ import { t } from "@rbxts/t";
 
 import { ComponentId, EntityId } from "../types/ecs";
 import { Immutable } from "../types/readonly";
-import { getNextComponentId } from "./entity-manager";
+import { getNextComponentId, internal_getGlobalEntityId } from "./entity-manager";
 import { Observer } from "./observer";
 
 type Mutable<T> = {
@@ -88,6 +88,13 @@ export const ComponentTypes = {
 	Vector3int16: [new Vector3int16()],
 };
 
+function componentInstantiationCheck(): void {
+	assert(
+		internal_getGlobalEntityId() === 0,
+		"Cannot create a component after entities have been created.",
+	);
+}
+
 export namespace ComponentInternalCreation {
 	/**
 	 * Creates a component that matches the given schema.
@@ -115,6 +122,8 @@ export namespace ComponentInternalCreation {
 	 * @returns A single component instance.
 	 */
 	export function createComponent<T extends Tree<Type>>(schema: T): Component<T> {
+		componentInstantiationCheck();
+
 		const componentData = createComponentArray<T>(schema as T, 10000);
 		const observers = new Array<Observer<T>>();
 		return Sift.Dictionary.merge(componentData, {
@@ -163,6 +172,8 @@ export namespace ComponentInternalCreation {
 	 * @returns A tag component.
 	 */
 	export function createTag(): TagComponent {
+		componentInstantiationCheck();
+
 		return {
 			componentId: getNextComponentId(),
 		} as TagComponentInternal;
@@ -181,6 +192,8 @@ export namespace ComponentInternalCreation {
 	 * @returns A flyweight component.
 	 */
 	export function createFlyweight<T extends object>(schema: T): Flyweight<T> {
+		componentInstantiationCheck();
+
 		const flyweight = Sift.Dictionary.merge(schema, {
 			componentId: getNextComponentId(),
 

--- a/src/lib/ecs/entity-manager.ts
+++ b/src/lib/ecs/entity-manager.ts
@@ -16,6 +16,10 @@ export function internal_resetGlobalState(): void {
 	reusableEntityIds = new SparseSet();
 }
 
+export function internal_getGlobalEntityId(): number {
+	return globalEntityId;
+}
+
 /**
  * @returns the next available component id.
  */


### PR DESCRIPTION
##### Description

If components are created after entities are added then the entity component mask will be incorrect, and it will throw errors.

This PR will throw an error if a component is created too late. In the future we may look at adding some sort of runtime components if needed, but this would require a lot of internal changes.
