### PR TITLE
fix(ecs): items throwing on no entities matched

### DIFF
--- a/src/lib/ecs/query.spec.ts
+++ b/src/lib/ecs/query.spec.ts
@@ -15,6 +15,10 @@ type MockComponent = {
 	set(): void;
 };
 
+function shallowEquals<T extends defined>(a: Array<T>, b: Array<T>): boolean {
+	return a.join() === b.join();
+}
+
 function createMockComponent(id: number): MockComponent {
 	return {
 		componentData: [],
@@ -198,9 +202,34 @@ export = (): void => {
 				const query = tempWorld.createQuery(ALL(component));
 				const allEntities = query.items();
 
-				print(allEntities);
-
 				expect(allEntities.size()).to.equal(4);
+			});
+
+			it("have a size of 0 when no entities match", () => {
+				internal_resetGlobalState();
+				const tempWorld = new World();
+
+				const component = ComponentInternalCreation.createComponent({
+					componentData: [],
+				});
+
+				const component1 = ComponentInternalCreation.createComponent({
+					componentData: [],
+				});
+
+				const id1 = tempWorld.add();
+				const id2 = tempWorld.add();
+
+				tempWorld.addComponent(id1, component);
+
+				tempWorld.flush();
+
+				const query = tempWorld.createQuery(ALL(component1));
+				const allEntities = query.items();
+
+				expect(allEntities.size()).to.equal(0);
+				expect(shallowEquals(allEntities, [])).to.equal(true);
+
 			});
 		});
 

--- a/src/lib/ecs/query.ts
+++ b/src/lib/ecs/query.ts
@@ -217,8 +217,8 @@ export class Query {
 	 * @returns an array of all the entities that currently match the query.
 	 */
 	public items(): Array<EntityId> {
-		const newArray = table.clone(this.archetypes[0].entities);
-		for (const i of $range(1, this.archetypes.size() - 1)) {
+		const newArray = new Array<number>(this.size());
+		for (const i of $range(0, this.archetypes.size() - 1)) {
 			const archetype = this.archetypes[i].entities;
 			archetype.move(0, archetype.size(), newArray.size(), newArray);
 		}


### PR DESCRIPTION
##### Description

If the query did not match any entities, it would try to access an undefined array. This fixes that by ensuring we always have an array first.
