### PR TITLE
fix: component types not allowed

### DIFF
--- a/src/lib/ecs/component.ts
+++ b/src/lib/ecs/component.ts
@@ -10,6 +10,8 @@ type Mutable<T> = {
 	-readonly [P in keyof T]: T[P];
 };
 
+export type AllComponentTypes = AnyComponent | TagComponent | AnyFlyweight;
+
 export type AnyComponent = Component<Tree<Type>>;
 export type AnyComponentInternal = ComponentInternal<Tree<Type>>;
 

--- a/src/lib/ecs/observer.ts
+++ b/src/lib/ecs/observer.ts
@@ -1,5 +1,5 @@
 import { EntityId } from "../types/ecs";
-import { AnyComponent, AnyComponentInternal } from "./component";
+import { AllComponentTypes, AnyComponent, AnyComponentInternal } from "./component";
 import { World } from "./world";
 
 /**
@@ -22,13 +22,13 @@ import { World } from "./world";
  */
 export class Observer {
 	/** A set of components that must match for an entity to be valid. */
-	private requiredComponents: Array<AnyComponent> = [];
+	private requiredComponents: Array<AllComponentTypes> = [];
 
 	/** The world this observer belongs to. */
 	public readonly world: World;
 
 	/** The primary component that the observer is watching. */
-	public primaryComponent: AnyComponent;
+	public primaryComponent: AllComponentTypes;
 	/**
 	 * A cache of all entities that match the observer.
 	 *
@@ -40,7 +40,7 @@ export class Observer {
 	 */
 	public storage: Set<EntityId> = new Set();
 
-	constructor(world: World, component: AnyComponent) {
+	constructor(world: World, component: AllComponentTypes) {
 		this.world = world;
 		this.primaryComponent = component;
 		(component as AnyComponentInternal).observers.push(this);
@@ -56,7 +56,7 @@ export class Observer {
 			let valid = true;
 
 			for (const component of this.requiredComponents) {
-				if (valid && !this.world.hasComponent(entityId, component)) {
+				if (valid && !this.world.hasComponent(entityId, component as AnyComponent)) {
 					valid = false;
 				}
 			}
@@ -86,7 +86,7 @@ export class Observer {
 	 *
 	 * @returns The observer instance.
 	 */
-	public with(component: AnyComponent): this {
+	public with(component: AllComponentTypes): this {
 		this.requiredComponents.push(component);
 
 		return this;

--- a/src/lib/ecs/query.ts
+++ b/src/lib/ecs/query.ts
@@ -1,12 +1,12 @@
 import { ComponentId, EntityId } from "../types/ecs";
 import { Archetype } from "./collections/archetype";
 import { SparseSet } from "./collections/sparse-set";
-import { AnyComponent, AnyComponentInternal, TagComponent } from "./component";
+import { AllComponentTypes, AnyComponentInternal } from "./component";
 import { World } from "./world";
 
 export type RawQuery =
-	| { op: typeof ALL | typeof ANY; dt: Array<RawQuery | AnyComponent | TagComponent> }
-	| { op: typeof NOT; dt: RawQuery | AnyComponent | TagComponent };
+	| { op: typeof ALL | typeof ANY; dt: Array<RawQuery | AllComponentTypes> }
+	| { op: typeof NOT; dt: RawQuery | AllComponentTypes };
 
 type MLeaf = { op: typeof ALL | typeof ANY; dt: Array<number> };
 type Group = { op: typeof ALL | typeof ANY; dt: [MLeaf, ...Array<QueryMask>] };
@@ -30,7 +30,7 @@ type QueryMask = Group | Not | MLeaf;
  *
  * @param components The components or query to match to.
  */
-export function ALL(...components: Array<RawQuery | AnyComponent | TagComponent>): RawQuery {
+export function ALL(...components: Array<RawQuery | AllComponentTypes>): RawQuery {
 	if (components.size() === 0) {
 		throw "ALL must have at least one component";
 	}
@@ -55,7 +55,7 @@ export function ALL(...components: Array<RawQuery | AnyComponent | TagComponent>
  *
  * @param components The components or query to match to.
  */
-export function ANY(...components: Array<RawQuery | AnyComponent | TagComponent>): RawQuery {
+export function ANY(...components: Array<RawQuery | AllComponentTypes>): RawQuery {
 	if (components.size() === 0) {
 		throw "ANY must have at least one component";
 	}
@@ -80,7 +80,7 @@ export function ANY(...components: Array<RawQuery | AnyComponent | TagComponent>
  *
  * @param components The components or query to match to.
  */
-export function NOT(components: RawQuery | AnyComponent | TagComponent): RawQuery {
+export function NOT(components: RawQuery | AllComponentTypes): RawQuery {
 	return {
 		op: NOT,
 		dt: typeOf((components as RawQuery).op) === "function" ? components : ALL(components),

--- a/src/lib/ecs/world.ts
+++ b/src/lib/ecs/world.ts
@@ -7,6 +7,7 @@ import { slice } from "../util/array-utils";
 import { Archetype } from "./collections/archetype";
 import { SparseSet } from "./collections/sparse-set";
 import {
+	AllComponentTypes,
 	AnyComponent,
 	AnyComponentInternal,
 	AnyFlyweight,
@@ -57,7 +58,7 @@ export class World {
 	/** Components that are waiting to be added or removed from an entity. */
 	private componentsToUpdate: SparseSet = new SparseSet();
 	/** A set of any component with a registered observer. */
-	private observers: Map<AnyComponent, Observer> = new Map();
+	private observers: Map<AllComponentTypes, Observer> = new Map();
 	/** A set of all queries that match entities in the world. */
 	private queries: Array<Query> = [];
 
@@ -190,10 +191,7 @@ export class World {
 	 * @returns A new {@link Query}.
 	 */
 	public createQuery(
-		...raw: [
-			RawQuery | AnyComponent | TagComponent,
-			...Array<RawQuery | AnyComponent | TagComponent>,
-		]
+		...raw: [RawQuery | AllComponentTypes, ...Array<RawQuery | AllComponentTypes>]
 	): Query {
 		let query: Query;
 
@@ -302,9 +300,9 @@ export class World {
 	 *
 	 * @returns Whether or not the entity has all of the given components.
 	 */
-	public hasAllOf(entityId: EntityId, ...components: Array<AnyComponent>): boolean {
+	public hasAllOf(entityId: EntityId, ...components: Array<AllComponentTypes>): boolean {
 		for (const component of components) {
-			if (!this.hasComponent(entityId, component)) {
+			if (!this.hasComponent(entityId, component as AnyComponent)) {
 				return false;
 			}
 		}
@@ -322,9 +320,9 @@ export class World {
 	 * @returns whether or not the entity has at least one of of the given
 	 * components.
 	 */
-	public hasAnyOf(entityId: EntityId, ...components: Array<AnyComponent>): boolean {
+	public hasAnyOf(entityId: EntityId, ...components: Array<AllComponentTypes>): boolean {
 		for (const component of components) {
-			if (this.hasComponent(entityId, component)) {
+			if (this.hasComponent(entityId, component as AnyComponent)) {
 				return true;
 			}
 		}


### PR DESCRIPTION
Observers didn't allow flyweights or tags, so this fixes that. 

In follow up there was a few places that didn't properly accept the correct component types, so this should fix this.