### PR TITLE
fix: systems scheduled after enabled

### DIFF
--- a/src/lib/ecs/system.ts
+++ b/src/lib/ecs/system.ts
@@ -1,6 +1,7 @@
 import { RunService } from "@rbxts/services";
 
 import { EventListener } from "../events";
+import { EntityId } from "../types/ecs";
 import { insertionSort } from "../util/array-utils";
 import { World } from "./world";
 
@@ -129,6 +130,7 @@ export abstract class System {
  * any system in a given world.
  */
 export class SystemManager {
+	private entitiesSetupInInitilization: Array<EntityId> = [];
 	private executionDefault: ExecutionGroup;
 	private executionGroupSignals: Map<ExecutionGroup, RBXScriptConnection> = new Map();
 	private executionGroups: Set<ExecutionGroup> = new Set();
@@ -469,7 +471,7 @@ export class SystemManager {
 	private runSystems(executionGroup: ExecutionGroup): void {
 		for (const system of this.systemsByExecutionGroup.get(executionGroup)!) {
 			if (!system.enabled) {
-				return;
+				continue;
 			}
 
 			system.dt = os.clock() - system.lastCalled;

--- a/src/lib/ecs/system.ts
+++ b/src/lib/ecs/system.ts
@@ -139,7 +139,6 @@ export abstract class System {
  * any system in a given world.
  */
 export class SystemManager {
-	private entitiesSetupInInitilization: Array<EntityId> = [];
 	private executionDefault: ExecutionGroup;
 	private executionGroupSignals: Map<ExecutionGroup, ConnectionLike> = new Map();
 	private executionGroups: Set<ExecutionGroup> = new Set();


### PR DESCRIPTION
If a system was scheduled after a disabled system, the system would
never run as the loop was being early exited.

