### PR TITLE
fix: flyweight wrong type on export

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -196,7 +196,7 @@ namespace Tina {
 	 *
 	 * @returns A flyweight component.
 	 */
-	export function createFlyweight<T extends Tree<Type>>(schema: T): Flyweight<T> {
+	export function createFlyweight<T extends object>(schema: T): Flyweight<T> {
 		return ComponentInternalCreation.createFlyweight(schema);
 	}
 }


### PR DESCRIPTION
The Tina.createFlyweight used the wrong object type compared to the internal createFlyweight.