### PR TITLE
feat(events): disconnect & type fixes/changes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@rbxts/tina",
-  "version": "0.1.3",
+  "version": "0.1.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@rbxts/tina",
-      "version": "0.1.3",
+      "version": "0.1.5",
       "license": "ISC",
       "dependencies": {
         "@eslint/github-action": "^0.1.0",

--- a/src/lib/conditions/types.d.ts
+++ b/src/lib/conditions/types.d.ts
@@ -1,6 +1,7 @@
-export declare type Condition<T extends Array<unknown> = Array<unknown>> =
-	| ConditionCallback<T>
+export declare type Condition<T> =
+	| ConditionCallback<T extends Array<unknown> ? T : [arg: T]>
 	| boolean;
+
 export declare type ConditionCallback<T extends Array<unknown> = Array<unknown>> = (
-	...args: [...T]
-) => boolean; // Being able to take arguments opens the possibility for events chaining to pass before-data to the condition itself.
+	...args: T
+) => boolean;


### PR DESCRIPTION
##### Description

Changes within EventEmitter and other areas which uses EventListeners.

##### Proposed Changes

  - Add a `.disconnect` method for the `EventEmitter` abstract class.
  - Change types for `EventListener` to take single objects instead of arrays.
  - `.await` should return the last return from the chain.

##### Tasks

  - [x] `.disconnect` method.
  - [x] `.await` return.
  - [x] Type changes.

##### Notes

Simple change, some sample code demonstrating the newest functionality.

```ts
class EventTesting extends EventEmitter<{ testing: number }> {
    constructor() {
        super();
    }
}

const Test = new EventTesting();

task.spawn(() => {
    const value = Test.when("testing")
	.do((num) => {
	    return num + 1;
	})
	.await();

    print(value);
});

task.delay(1, () => {
    Test.emit("testing", 1);
});
```

##### Linked

Resolves #70 
Resolves #82 