### PR TITLE
feat(events): change await, add clear & disconnect methods

### DIFF
--- a/src/lib/events/index.ts
+++ b/src/lib/events/index.ts
@@ -34,7 +34,7 @@ export class EventListener<T extends Array<unknown> = Array<unknown>> {
 	 *
 	 * @returns The same EventListener chain, any following functions will receive as parameters whatever the last do function returned.
 	 */
-	public condition(condition: Condition<[data: T]>): EventListener<T> {
+	public condition(condition: Condition<T>): EventListener<T> {
 		this.head = {
 			value: [condition, EAction.COND] as CondFunc,
 			next: this.head,
@@ -126,15 +126,15 @@ export abstract class EventEmitter<Events extends Default | {}> {
 	 * Emits the event, either resuming the yeilded threads or invoking the do's chain.
 	 *
 	 * @param token Event to emit.
-	 * @param data Type `T`, a single object.
+	 * @param args Type `T`, a single object.
 	 */
 	public emit<X extends keyof Events, S extends ArrayOrNever<Events[X]>>(
 		token: X,
-		...data: S
+		...args: S
 	): void {
 		if (token in this.events) {
 			for (const thread of this.events[token as string]) {
-				void thread.call(token === "_default" ? [] : data);
+				void thread.call(...(token === "_default" ? [] : args));
 			}
 		}
 	}

--- a/src/lib/events/index.ts
+++ b/src/lib/events/index.ts
@@ -43,7 +43,10 @@ export class EventListener<T extends Array<unknown> = Array<unknown>> {
 	public await(): LuaTuple<T> {
 		this.yieldThreads.push(coroutine.running());
 
-		return coroutine.yield() as LuaTuple<T>;
+		let data = coroutine.yield() as LuaTuple<T>;
+
+		table.clear(this.listeners);
+		return data;
 	}
 
 	/**

--- a/src/lib/events/index.ts
+++ b/src/lib/events/index.ts
@@ -8,7 +8,7 @@ export enum EAction {
 }
 
 export class EventListener<T extends Array<unknown> = Array<unknown>> {
-	private _head!: EventNode;
+	private head: EventNode;
 
 	protected readonly yieldThreads: Array<thread> = [];
 
@@ -20,10 +20,10 @@ export class EventListener<T extends Array<unknown> = Array<unknown>> {
 	 * @param func
 	 * @returns The same EventListener chain, any following functions will receive as parameters whatever this function returned.
 	 */
-	public do<X>(func: (...args: [...T]) => X): EventListener<[X]> {
-		this._head = {
+	public do<X>(func: (...args: T) => X): EventListener<[X]> {
+		this.head = {
 			value: [func, EAction.DO],
-			_next: this._head,
+			next: this.head,
 		};
 
 		return this as unknown as EventListener<[X]>;
@@ -34,27 +34,34 @@ export class EventListener<T extends Array<unknown> = Array<unknown>> {
 	 *
 	 * @returns The same EventListener chain, any following functions will receive as parameters whatever the last do function returned.
 	 */
-	public condition(condition: Condition<T>): EventListener<T> {
-		this._head = {
+	public condition(condition: Condition<[data: T]>): EventListener<T> {
+		this.head = {
 			value: [condition, EAction.COND] as CondFunc,
-			_next: this._head,
+			next: this.head,
 		};
 
 		return this as unknown as EventListener<T>;
 	}
 
 	/**
-	 * Yields current thread until resumption (emit call).
+	 * Awaits for the final result on the last do of this chain.
 	 */
-	public await(): LuaTuple<Array<unknown>> {
+	public await(): LuaTuple<T> {
 		this.yieldThreads.push(coroutine.running());
 
-		return coroutine.yield();
+		return coroutine.yield() as LuaTuple<T>;
+	}
+
+	/**
+	 * Clears all the binded conditions and dos to this specific EventListener.
+	 */
+	public disconnect(): void {
+		this.head = undefined;
 	}
 
 	/** @hidden */
-	public async call<T extends Array<unknown>>(...args: T): Promise<void> {
-		let item = this._head;
+	public async call<X extends Array<unknown> = Array<unknown>>(...args: X): Promise<void> {
+		let item = this.head;
 
 		let lastArgument = args;
 		let lastCondition = true;
@@ -65,7 +72,7 @@ export class EventListener<T extends Array<unknown> = Array<unknown>> {
 			if (_type === EAction.DO) {
 				if (lastCondition === true) {
 					try {
-						lastArgument = [handler(...lastArgument)] as T;
+						lastArgument = [handler(...lastArgument)] as X;
 					} catch (e) {
 						warn(`[Tina:Event]: There has been an error, more information. ${e}`);
 					}
@@ -74,33 +81,31 @@ export class EventListener<T extends Array<unknown> = Array<unknown>> {
 				lastCondition = COND.eval(handler, ...lastArgument);
 			}
 
-			item = item._next;
+			item = item.next;
 		}
 
 		if (this.yieldThreads.size() > 0) {
-			for (const thread of this.yieldThreads) coroutine.resume(thread);
+			for (const thread of this.yieldThreads) coroutine.resume(thread, ...lastArgument);
 		}
 	}
 }
 
 export abstract class EventEmitter<Events extends Default | {}> {
-	protected readonly events: Record<string, Array<EventListener<[]>>> = {};
+	protected readonly events: Record<string, Array<EventListener>> = {};
 
 	/**
-	 * Lets you listen to a specific event from your Events interface definition.
+	 * Binds an EventListener to your Event, from where you can bind callbacks to be invoked when even is emitted.
 	 *
-	 * @param token as string, should be the event to connect to.
-	 * @returns an EventListener of type T which are the parameters passed to the function.
+	 * @param token Event to bind to.
+	 * @returns An EventListener.
 	 */
-	public when<T extends keyof Events, U extends Events[T]>(
-		token?: T,
+	public when<X extends keyof Events, U extends Events[X]>(
+		token?: X,
 	): typeof token extends void
 		? EventListener<Events extends Default ? Events["_default"] : never>
 		: EventListener<U extends Array<unknown> ? U : never>;
 
-	public when<T extends keyof Events>(token: T): EventListener<ArrayOrNever<Events[T]>>;
-
-	// Implementation
+	public when<X extends keyof Events>(token: X): EventListener<ArrayOrNever<Events[X]>>;
 
 	public when(token = "_default"): unknown {
 		const event = new EventListener();
@@ -120,19 +125,30 @@ export abstract class EventEmitter<Events extends Default | {}> {
 	/**
 	 * Emits the event, either resuming the yeilded threads or invoking the do's chain.
 	 *
-	 * @param token event to emit.
-	 * @param args of type T which are the parameters passed to the function definition.
-	 *
-	 * @returns a promise.
+	 * @param token Event to emit.
+	 * @param data Type `T`, a single object.
 	 */
-	public emit<T extends keyof Events, S extends ArrayOrNever<Events[T]>>(
-		token: T,
-		...args: S
+	public emit<X extends keyof Events, S extends ArrayOrNever<Events[X]>>(
+		token: X,
+		...data: S
 	): void {
 		if (token in this.events) {
 			for (const thread of this.events[token as string]) {
-				void thread.call(...(token === "_default" ? [] : args));
+				void thread.call(token === "_default" ? [] : data);
 			}
+		}
+	}
+
+	/**
+	 * It clears an Event, deletes and disconnects every event listener binded to it.
+	 *
+	 * @param token Event to remove EventListeners from.
+	 */
+	public clear<X extends keyof Events>(token: X): void;
+
+	public clear(token = "_default"): void {
+		if (token in this.events) {
+			return void table.clear(this.events[token]);
 		}
 	}
 }

--- a/src/lib/events/index.ts
+++ b/src/lib/events/index.ts
@@ -45,7 +45,6 @@ export class EventListener<T extends Array<unknown> = Array<unknown>> {
 
 		let data = coroutine.yield() as LuaTuple<T>;
 
-		table.clear(this.listeners);
 		return data;
 	}
 

--- a/src/lib/events/types.d.ts
+++ b/src/lib/events/types.d.ts
@@ -6,10 +6,12 @@ export declare type ArrayOrNever<T> = T extends Array<unknown> ? T : never;
 export declare type CondFunc = [Condition, EAction.COND];
 export declare type StepFunc = [Callback, EAction.DO];
 
-export declare type EventNode = {
-	value: CondFunc | StepFunc;
-	_next: EventNode;
-};
+export declare type EventNode =
+	| {
+			value: CondFunc | StepFunc;
+			next: EventNode;
+	  }
+	| undefined;
 
 export interface Default {
 	_default: Array<unknown>;


### PR DESCRIPTION
##### Description

Changes within EventEmitter and other areas which uses EventListeners.

##### Proposed Changes

  - Add a `.disconnect` method for the `EventEmitter` abstract class.
  - Change types for `EventListener` to take single objects instead of arrays.
  - `.await` should return the last return from the chain.

##### Tasks

  - [x] `.disconnect` method.
  - [x] `.await` return.
  - [ ] Type changes (as a maybe TODO in the future).

##### Notes

Simple change, some sample code demonstrating the newest functionality.

```ts
class EventTesting extends EventEmitter<{ _default: number }> {
    constructor() {
        super();
    }
}

const Test = new EventTesting();

task.spawn(() => {
    const [value] = Test.when()
	.do((num) => {
	    return num + 1;
	})
	.await();

    print(value); // 2
});

task.delay(1, () => {
    Test.emit("_default", 1);
});
```

##### Linked

Resolves #70 
Resolves #82 