### PR TITLE
perf: remove sparse set creation on exited/entered query

### DIFF
--- a/src/lib/ecs/collections/sparse-set.ts
+++ b/src/lib/ecs/collections/sparse-set.ts
@@ -9,6 +9,8 @@
 export class SparseSet {
 	/** The elements stored in the sparse set. */
 	public dense: Array<number> = [];
+	/** The size of the sparse set. */
+	public size = 0;
 	/** An array that maps the set's items to their indices in the dense. */
 	public sparse: Array<number> = [];
 
@@ -21,8 +23,19 @@ export class SparseSet {
 			return;
 		}
 
-		this.sparse[x] = this.dense.size();
-		this.dense.push(x);
+		this.sparse[x] = this.size;
+		this.dense[this.size] = x;
+		this.size++;
+	}
+
+	/**
+	 * Clears the sparse set.
+	 *
+	 * This will not free any memory allocated by the sparse set, and will
+	 * instead reset the size to 0 for quick reuse.
+	 */
+	public clear(): void {
+		this.size = 0;
 	}
 
 	/**
@@ -33,7 +46,7 @@ export class SparseSet {
 	 */
 	public has(x: number): boolean {
 		const sparse = this.sparse[x] ?? math.huge;
-		return sparse < this.dense.size() && this.dense[sparse] === x;
+		return sparse < this.size && this.dense[sparse] === x;
 	}
 
 	/**
@@ -45,10 +58,9 @@ export class SparseSet {
 			return;
 		}
 
-		const last = this.dense.pop()!;
-		if (x !== last) {
-			this.sparse[last] = this.sparse[x];
-			this.dense[this.sparse[x]] = last;
-		}
+		const last = this.dense[this.size - 1];
+		this.sparse[last] = this.sparse[x];
+		this.dense[this.sparse[x]] = last;
+		this.size--;
 	}
 }

--- a/src/lib/ecs/query.ts
+++ b/src/lib/ecs/query.ts
@@ -166,37 +166,31 @@ export class Query {
 	}
 
 	/**
-	 * Runs a callback for each entity that has been added to the query since
-	 * the last time this method was called.
+	 * Iterate over all entities that have entered the query since the last
+	 * time this method was called.
 	 *
-	 * If the callback returns `false`, the iteration will stop, and no other
-	 * entities in this query will be iterated over. Please note that this will
-	 * still flush the contents of the query, so the next call to this method
-	 * will not iterate over the same entities.
-	 *
-	 * As this method flushes the contents of the query, it can only be used
-	 * once. If you need to iterate over the same entities multiple times,
-	 * although unconventional, you can use the `Query.entered.dense` array
-	 * directly instead.
-	 *
-	 * @param callback The callback to run for each entity.
+	 * @note This cannot be iterated over multiple times as it will clear the
+	 * contents of the entered set. If you need to iterate over the same set
+	 * multiple times, although unconventional, you can do:
+	 * ```ts
+	 * const entered = query.entered.dense;
+	 * for (const i of $range(0, query.entered.size - 1)) {
+	 *     yield entered[i];
+	 * }
+	 * ```
 	 */
 	public *enteredQuery(): Generator<EntityId> {
-		for (const entityId of this.entered.dense) {
-			yield entityId;
+		const entered = this.entered.dense;
+		for (const i of $range(0, this.entered.size - 1)) {
+			yield entered[i];
 		}
 
-		this.entered = new SparseSet();
+		this.entered.clear();
 	}
 
 	/**
 	 * Runs a callback for each entity that has been removed from the query
-	 * since the last time this method was called.
-	 *
-	 * If the callback returns `false`, the iteration will stop, and no other
-	 * entities in this query will be iterated over. Please note that this will
-	 * still flush the contents of the query, so the next call to this method
-	 * will not iterate over the same entities.
+	 * since the last time this method was called. The
 	 *
 	 * As this method flushes the contents of the query, it can only be used
 	 * once. If you need to iterate over the same entities multiple times,
@@ -206,11 +200,12 @@ export class Query {
 	 * @param callback The callback to run for each entity.
 	 */
 	public *exitedQuery(): Generator<EntityId> {
-		for (const entityId of this.exited.dense) {
-			yield entityId;
+		const exited = this.exited.dense;
+		for (const i of $range(0, this.exited.size - 1)) {
+			yield exited[i];
 		}
 
-		this.exited = new SparseSet();
+		this.exited.clear();
 	}
 
 	/**
@@ -247,7 +242,7 @@ export class Query {
 		let size = 0;
 
 		for (const archetype of this.archetypes) {
-			size += archetype.entities.size();
+			size += archetype.sparseSet.size;
 		}
 
 		return size;

--- a/src/lib/ecs/query.ts
+++ b/src/lib/ecs/query.ts
@@ -166,31 +166,37 @@ export class Query {
 	}
 
 	/**
-	 * Iterate over all entities that have entered the query since the last
-	 * time this method was called.
+	 * Runs a callback for each entity that has been added to the query since
+	 * the last time this method was called.
 	 *
-	 * @note This cannot be iterated over multiple times as it will clear the
-	 * contents of the entered set. If you need to iterate over the same set
-	 * multiple times, although unconventional, you can do:
-	 * ```ts
-	 * const entered = query.entered.dense;
-	 * for (const i of $range(0, query.entered.size - 1)) {
-	 *     yield entered[i];
-	 * }
-	 * ```
+	 * If the callback returns `false`, the iteration will stop, and no other
+	 * entities in this query will be iterated over. Please note that this will
+	 * still flush the contents of the query, so the next call to this method
+	 * will not iterate over the same entities.
+	 *
+	 * As this method flushes the contents of the query, it can only be used
+	 * once. If you need to iterate over the same entities multiple times,
+	 * although unconventional, you can use the `Query.entered.dense` array
+	 * directly instead.
+	 *
+	 * @param callback The callback to run for each entity.
 	 */
 	public *enteredQuery(): Generator<EntityId> {
-		const entered = this.entered.dense;
-		for (const i of $range(0, this.entered.size - 1)) {
-			yield entered[i];
+		for (const entityId of this.entered.dense) {
+			yield entityId;
 		}
 
-		this.entered.clear();
+		this.entered = new SparseSet();
 	}
 
 	/**
 	 * Runs a callback for each entity that has been removed from the query
-	 * since the last time this method was called. The
+	 * since the last time this method was called.
+	 *
+	 * If the callback returns `false`, the iteration will stop, and no other
+	 * entities in this query will be iterated over. Please note that this will
+	 * still flush the contents of the query, so the next call to this method
+	 * will not iterate over the same entities.
 	 *
 	 * As this method flushes the contents of the query, it can only be used
 	 * once. If you need to iterate over the same entities multiple times,
@@ -200,12 +206,11 @@ export class Query {
 	 * @param callback The callback to run for each entity.
 	 */
 	public *exitedQuery(): Generator<EntityId> {
-		const exited = this.exited.dense;
-		for (const i of $range(0, this.exited.size - 1)) {
-			yield exited[i];
+		for (const entityId of this.exited.dense) {
+			yield entityId;
 		}
 
-		this.exited.clear();
+		this.exited = new SparseSet();
 	}
 
 	/**
@@ -242,7 +247,7 @@ export class Query {
 		let size = 0;
 
 		for (const archetype of this.archetypes) {
-			size += archetype.sparseSet.size;
+			size += archetype.entities.size();
 		}
 
 		return size;

--- a/src/lib/ecs/query.ts
+++ b/src/lib/ecs/query.ts
@@ -166,51 +166,49 @@ export class Query {
 	}
 
 	/**
-	 * Runs a callback for each entity that has been added to the query since
-	 * the last time this method was called.
+	 * Iterate over all entities that have entered the query since the last
+	 * time this method was called.
 	 *
-	 * If the callback returns `false`, the iteration will stop, and no other
-	 * entities in this query will be iterated over. Please note that this will
-	 * still flush the contents of the query, so the next call to this method
-	 * will not iterate over the same entities.
-	 *
-	 * As this method flushes the contents of the query, it can only be used
-	 * once. If you need to iterate over the same entities multiple times,
-	 * although unconventional, you can use the `Query.entered.dense` array
-	 * directly instead.
-	 *
-	 * @param callback The callback to run for each entity.
+	 * @note This cannot be iterated over multiple times as it will clear the
+	 * contents of the entered set. If you need to iterate over the same set
+	 * multiple times, although unconventional, you can do:
+	 * ```ts
+	 * const entered = query.entered.dense;
+	 * for (const i of $range(0, query.entered.size - 1)) {
+	 *     yield entered[i];
+	 * }
+	 * ```
 	 */
 	public *enteredQuery(): Generator<EntityId> {
-		for (const entityId of this.entered.dense) {
-			yield entityId;
+		const entered = this.entered.dense;
+		for (const i of $range(0, this.entered.size - 1)) {
+			yield entered[i];
 		}
 
-		this.entered = new SparseSet();
+		this.entered.clear();
 	}
 
 	/**
-	 * Runs a callback for each entity that has been removed from the query
-	 * since the last time this method was called.
+	 * Iterate over all entities that have exited the query since the last
+	 * time this method was called.
 	 *
-	 * If the callback returns `false`, the iteration will stop, and no other
-	 * entities in this query will be iterated over. Please note that this will
-	 * still flush the contents of the query, so the next call to this method
-	 * will not iterate over the same entities.
-	 *
-	 * As this method flushes the contents of the query, it can only be used
-	 * once. If you need to iterate over the same entities multiple times,
-	 * although unconventional, you can use the `Query.exited.dense` array
-	 * directly instead.
-	 *
-	 * @param callback The callback to run for each entity.
+	 * @note This cannot be iterated over multiple times as it will clear the
+	 * contents of the exited set. If you need to iterate over the same set
+	 * multiple times, although unconventional, you can do:
+	 * ```ts
+	 * const exited = query.exited.dense;
+	 * for (const i of $range(0, query.exited.size - 1)) {
+	 *     yield exited[i];
+	 * }
+	 * ```
 	 */
 	public *exitedQuery(): Generator<EntityId> {
-		for (const entityId of this.exited.dense) {
-			yield entityId;
+		const exited = this.exited.dense;
+		for (const i of $range(0, this.exited.size - 1)) {
+			yield exited[i];
 		}
 
-		this.exited = new SparseSet();
+		this.exited.clear();
 	}
 
 	/**
@@ -247,7 +245,7 @@ export class Query {
 		let size = 0;
 
 		for (const archetype of this.archetypes) {
-			size += archetype.entities.size();
+			size += archetype.sparseSet.size;
 		}
 
 		return size;

--- a/src/lib/ecs/system.ts
+++ b/src/lib/ecs/system.ts
@@ -194,43 +194,6 @@ export class SystemManager {
 	}
 
 	/**
-	 * Replaces a system with a new system. System storages will
-	 * @param oldSystem
-	 * @param newSystem
-	 */
-	public replaceSystem(oldSystem: System, newSystem: System): void {
-		const index = this.systems.indexOf(oldSystem);
-		if (index === -1) {
-			throw `System ${tostring(getmetatable(oldSystem))} not found`;
-		}
-
-		for (const storage of oldSystem.storage) {
-			storage.cleanup();
-		}
-
-		this.setupSystemStorage(newSystem);
-
-		this.systems[index] = newSystem;
-
-		if (oldSystem.executionGroup !== newSystem.executionGroup) {
-			const index = this.systemsByExecutionGroup
-				.get(oldSystem.executionGroup ?? this.executionDefault)
-				?.indexOf(oldSystem);
-			if (index === undefined) {
-				throw `System ${tostring(
-					getmetatable(oldSystem),
-				)} not found in execution group ${tostring(oldSystem.executionGroup)}`;
-			}
-
-			this.systemsByExecutionGroup
-				.get(oldSystem.executionGroup ?? this.executionDefault)
-				?.remove(index);
-		}
-
-		this.sortSystems(this.systems);
-	}
-
-	/**
 	 * Schedules an individual system.
 	 *
 	 * Calling this function is a potentially expensive operation. It is best

--- a/src/lib/ecs/system.ts
+++ b/src/lib/ecs/system.ts
@@ -194,6 +194,43 @@ export class SystemManager {
 	}
 
 	/**
+	 * Replaces a system with a new system. System storages will
+	 * @param oldSystem
+	 * @param newSystem
+	 */
+	public replaceSystem(oldSystem: System, newSystem: System): void {
+		const index = this.systems.indexOf(oldSystem);
+		if (index === -1) {
+			throw `System ${tostring(getmetatable(oldSystem))} not found`;
+		}
+
+		for (const storage of oldSystem.storage) {
+			storage.cleanup();
+		}
+
+		this.setupSystemStorage(newSystem);
+
+		this.systems[index] = newSystem;
+
+		if (oldSystem.executionGroup !== newSystem.executionGroup) {
+			const index = this.systemsByExecutionGroup
+				.get(oldSystem.executionGroup ?? this.executionDefault)
+				?.indexOf(oldSystem);
+			if (index === undefined) {
+				throw `System ${tostring(
+					getmetatable(oldSystem),
+				)} not found in execution group ${tostring(oldSystem.executionGroup)}`;
+			}
+
+			this.systemsByExecutionGroup
+				.get(oldSystem.executionGroup ?? this.executionDefault)
+				?.remove(index);
+		}
+
+		this.sortSystems(this.systems);
+	}
+
+	/**
 	 * Schedules an individual system.
 	 *
 	 * Calling this function is a potentially expensive operation. It is best


### PR DESCRIPTION
Currently everytime we wish to flush the changes made after enteredQuery() and exitedQuery() we are recreating a sparse set. This fixes this, with a slight performance hit for pure iteration, but with increased performance for addition, removal, and clearing.