### PR TITLE
fix: entities not matching exited query if destroyed

### DIFF
--- a/src/lib/ecs/entity-manager.ts
+++ b/src/lib/ecs/entity-manager.ts
@@ -88,6 +88,9 @@ export class EntityManager {
 	 */
 	public destroyPendingEntities(): void {
 		for (const entityId of this.entitiesToDestroy.dense) {
+			for (const query of this.entities[entityId].queries) {
+				query.exited.add(entityId);
+			}
 			this.entities[entityId].sparseSet.remove(entityId);
 			reusableEntityIds.add(entityId);
 			this.size--;


### PR DESCRIPTION
##### Description

Fixes entities not being added to exitedQuery when removed from the world. This is useful in cases where we might destroy an entity and wish in a DOM-related system to destroy any roblox instances that it was representing.