### PR TITLE
Refactor(ecs)! Update Component Types

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -2,6 +2,4 @@ examples/*
 example/*
 transformer/*
 
-# Tests, it's annoying
-*.spec.ts
 src/testBootstrap.server.ts

--- a/src/index.ts
+++ b/src/index.ts
@@ -225,7 +225,20 @@ export { type Query, ALL, ANY, NOT } from "./lib/ecs/query";
 export { bindEvent, Event } from "./lib/ecs/storage/event";
 export { StorageObject, System } from "./lib/ecs/system";
 export { type World } from "./lib/ecs/world";
-export * from "./lib/types/ecs";
+export {
+	AllComponentTypes,
+	AnyComponent,
+	AnyFlyweight,
+	Component,
+	ComponentData,
+	ComponentId,
+	EntityId,
+	Flyweight,
+	FlyweightData,
+	GetComponentSchema,
+	PartialComponentToKeys,
+	TagComponent,
+} from "./lib/types/ecs";
 
 /** Users namespace */
 export { User, Users } from "./lib/user";

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,14 +2,7 @@ import { RunService } from "@rbxts/services";
 
 import TinaCore from "./lib/core";
 import TinaGame from "./lib/core/game";
-import {
-	Component,
-	ComponentInternalCreation,
-	Flyweight,
-	TagComponent,
-	Tree,
-	Type,
-} from "./lib/ecs/component";
+import { ComponentInternalCreation } from "./lib/ecs/component";
 import { World, WorldOptions } from "./lib/ecs/world";
 import { EventListener } from "./lib/events";
 import { TinaEvents } from "./lib/events/internal";
@@ -21,6 +14,7 @@ import { Identifiers } from "./lib/net/util/identifiers";
 import { Server } from "./lib/net/util/server";
 import { Process } from "./lib/process/process";
 import Scheduler from "./lib/process/scheduler";
+import { Component, ComponentData, Flyweight, FlyweightData, TagComponent } from "./lib/types/ecs";
 import { Users } from "./lib/user";
 import { DefaultUserDeclaration } from "./lib/user/default/types";
 
@@ -170,7 +164,7 @@ namespace Tina {
 	 *
 	 * @returns A single component instance.
 	 */
-	export function createComponent<T extends Tree<Type>>(schema: T): Component<T> {
+	export function createComponent<T extends ComponentData>(schema: T): Component<T> {
 		return ComponentInternalCreation.createComponent(schema);
 	}
 
@@ -204,7 +198,7 @@ namespace Tina {
 	 *
 	 * @returns A flyweight component.
 	 */
-	export function createFlyweight<T extends object>(schema: T): Flyweight<T> {
+	export function createFlyweight<T extends FlyweightData>(schema: T): Flyweight<T> {
 		return ComponentInternalCreation.createFlyweight(schema);
 	}
 }
@@ -225,13 +219,13 @@ export { Network } from "./lib/net";
 export { Audience } from "./lib/audience/audience";
 
 /** ECS Library  */
-export { Component, ComponentTypes, GetComponentSchema } from "./lib/ecs/component";
+export { ComponentTypes } from "./lib/ecs/component";
 export { Observer } from "./lib/ecs/observer";
 export { type Query, ALL, ANY, NOT } from "./lib/ecs/query";
 export { bindEvent, Event } from "./lib/ecs/storage/event";
 export { StorageObject, System } from "./lib/ecs/system";
 export { type World } from "./lib/ecs/world";
-export { ComponentId, EntityId } from "./lib/types/ecs";
+export * from "./lib/types/ecs";
 
 /** Users namespace */
 export { User, Users } from "./lib/user";

--- a/src/lib/ecs/collections/archetype.ts
+++ b/src/lib/ecs/collections/archetype.ts
@@ -1,4 +1,5 @@
-import { ComponentId, EntityId } from "../../types/ecs";
+import { EntityId } from "../../types/ecs";
+import { ComponentBitmask } from "../component";
 import { Query } from "../query";
 import { SparseSet } from "./sparse-set";
 
@@ -18,11 +19,11 @@ export class Archetype {
 
 	public change: Array<Archetype> = [];
 	/** The type of the archetype denoted by all its relevant components. */
-	public mask: Array<ComponentId>;
+	public mask: ComponentBitmask;
 	/** All queries that are interested in this archetype. */
 	public queries: Array<Query> = [];
 
-	constructor(mask: Array<ComponentId>) {
+	constructor(mask: ComponentBitmask) {
 		this.entities = this.sparseSet.dense;
 		this.mask = mask;
 	}

--- a/src/lib/ecs/component.ts
+++ b/src/lib/ecs/component.ts
@@ -1,35 +1,58 @@
-import Sift, { None } from "@rbxts/sift";
+import Sift from "@rbxts/sift";
 import { t } from "@rbxts/t";
 
-import { ComponentId, EntityId } from "../types/ecs";
-import { Immutable } from "../types/readonly";
+import {
+	Component,
+	ComponentData,
+	ComponentId,
+	EntityId,
+	Flyweight,
+	FlyweightData,
+	PartialComponentToKeys,
+	TagComponent,
+} from "../types/ecs";
 import { getNextComponentId, internal_getGlobalEntityId } from "./entity-manager";
 import { Observer } from "./observer";
 
-type Mutable<T> = {
-	-readonly [P in keyof T]: T[P];
+export type ComponentBitmask = Array<number>;
+
+export type Internal<T> = T extends Component<infer K>
+	? ComponentInternal<K>
+	: T extends Flyweight<infer K>
+	? FlyweightInternal<K>
+	: T extends TagComponent
+	? TagComponentInternal
+	: T extends object
+	? object & ComponentIdField
+	: never;
+
+export type ComponentInternal<T extends ComponentData> = Component<T> &
+	ComponentIdField & {
+		observers: Array<Observer>;
+	};
+export type FlyweightInternal<T extends FlyweightData> = Flyweight<T> & ComponentIdField;
+export type TagComponentInternal = object & ComponentIdField;
+
+export type ComponentIdField = {
+	readonly componentId: ComponentId;
+	readonly componentType: ComponentType;
 };
 
-export type AllComponentTypes = AnyComponent | TagComponent | AnyFlyweight;
+export type ComponentInternalFields<T extends ComponentData> = ComponentMethods<T> &
+	ComponentIdField & {
+		observers: Array<Observer>;
+	};
 
-export type AnyComponent = Component<Tree<Type>>;
-export type AnyComponentInternal = ComponentInternal<Tree<Type>>;
+export type FlyweightInternalFields<T extends FlyweightData> = FlyweightMethods<T> &
+	ComponentIdField;
 
-export type AnyFlyweight = Flyweight<object>;
-
-export type GetComponentSchema<C> = C extends Component<infer T> ? T : never;
-
-export type ComponentData<T extends Tree<Type>> = T extends Array<infer U> ? Array<U> : T;
-
-export type OptionalKeys<T> = { [K in keyof T]: (T[K] extends Array<infer U> ? U : never) | None };
-
-export type Component<T extends Tree<Type>> = Mutable<ComponentData<T>> & {
+export type ComponentMethods<T extends ComponentData> = {
 	/**
 	 * The default values for this component. This is used when adding a
 	 * component to an entity; each property that is specified in this object
 	 * will be given to the entity.
 	 */
-	setDefaults?: () => Partial<OptionalKeys<T>>;
+	setDefaults?: () => PartialComponentToKeys<T>;
 	/**
 	 * Clones all the data from one entity to another. This will
 	 * overwrite any existing data for the target entity. If you want
@@ -59,48 +82,21 @@ export type Component<T extends Tree<Type>> = Mutable<ComponentData<T>> & {
 	 * @param entityId The entity to update.
 	 * @param data The data to update.
 	 */
-	set(entityId: EntityId, data: Partial<OptionalKeys<T>>): void;
+	set(entityId: EntityId, data: PartialComponentToKeys<T>): void;
 };
 
-export type ComponentInternal<T extends Tree<Type>> = Component<T> &
-	ComponentIdField & {
-		observers: Array<Observer>;
-	};
-
-export type TagComponent = {
-	[index: string]: never;
+export type FlyweightMethods<T extends FlyweightData> = {
+	set(data: Partial<T>): void;
 };
 
-export type TagComponentInternal = ComponentIdField & {
-	[index: string]: never;
-};
+export enum ComponentType {
+	Component,
+	Flyweight,
+	Tag,
+}
 
-export type Flyweight<T extends object> = Immutable<T> & {
-	set<U extends Partial<T>>(data: U): void;
-};
-
-export type FlyweightInternal<T extends object> = Flyweight<T> & ComponentIdField;
-
-export type Tree<LeafType> = LeafType | { [key: string]: Tree<LeafType> };
-
-export type Type = ArrayConstructor | Array<unknown>;
-
-export type ComponentArray<T extends Tree<Type> = Tree<Type>> = T extends Array<unknown>
-	? T
-	: T extends ArrayConstructor
-	? Array<typeof ComponentTypes>
-	: T extends Exclude<Type, Array<unknown>>
-	? InstanceType<T>
-	: {
-			[key in keyof T]: T[key] extends Tree<Type> ? ComponentArray<T[key]> : never;
-	  };
-
-type ComponentIdField = { readonly componentId: ComponentId };
-
-function Custom<T>(init: () => T): [() => T];
-function Custom<T>(): Array<T>;
-function Custom<T>(init?: () => T): Array<() => T> {
-	return init ? [init] : [];
+function Custom<T>(): Array<T> {
+	return new Array<T>();
 }
 
 /**
@@ -150,89 +146,78 @@ export namespace ComponentInternalCreation {
 	 * one component per world. EntityIds are global, therefore the index of a
 	 * given entity will always match the index of the component data.
 	 *
-	 * TODO: Currently this is hardcoded to use 10000 entities, how can we allow
-	 * this to be configurable? It should also be possible to resize the array if
-	 * required (although this would not be desirable).
-	 *
 	 * @param schema The properties of the component.
 	 *
 	 * @returns A single component instance.
 	 */
-	export function createComponent<T extends Tree<Type>>(schema: T): Component<T> {
+	export function createComponent<T extends ComponentData>(schema: T): Component<T> {
 		componentInstantiationCheck();
 
-		const componentData = createComponentArray<T>(schema as T, 10000);
+		// TODO: Remove hard coded size in favor of tina manifest.
+		const componentData = createComponentArray(schema as T, 10000);
 		const observers = new Array<Observer>();
-		return Sift.Dictionary.merge<[ComponentArray<T>, ComponentInternal<Tree<Type>>]>(
-			componentData,
-			{
-				componentId: getNextComponentId(),
-				setDefaults: undefined,
-				observers: observers,
-
-				/**
-				 * Clones all the data from one entity to another. This will
-				 * overwrite any existing data for the target entity. If you want
-				 * to copy specific properties, then you should do this manually.
-				 *
-				 * @param fromEntityId The entity to copy from.
-				 * @param toEntityId The entity to copy to.
-				 */
-				clone(fromEntityId: EntityId, toEntityId: EntityId): void {
-					// eslint-disable-next-line roblox-ts/no-array-pairs
-					for (const [key] of pairs(componentData)) {
-						componentData[key as never][toEntityId as never] =
-							componentData[key as never][fromEntityId as never];
-					}
-				},
-
-				/**
-				 * Resets the data for the given entity to the default values if
-				 * they are defined.
-				 *
-				 * @param entityId The entity to reset.
-				 */
-				reset(entityId: EntityId): void {
-					if (this.setDefaults === undefined) {
-						return;
-					}
-
-					const data = this.setDefaults();
-
-					// eslint-disable-next-line roblox-ts/no-array-pairs
-					for (const [key, value] of pairs(componentData)) {
-						// TODO: I hate this
-						componentData[key as never][entityId as never] = data[key as never];
-					}
-				},
-
-				/**
-				 * Sets the data for the given entity.
-				 *
-				 * The set function is used to update any observers that are
-				 * watching the given component. If there are no observers, then it
-				 * is recommended to use the component data directly.
-				 *
-				 * There is no equality check, so it is recommended to only use this
-				 * function when the data has changed.
-				 *
-				 * @param entityId The entity to update.
-				 * @param data The data to update.
-				 */
-				set(entityId: EntityId, data: Partial<OptionalKeys<T>>): void {
-					for (const observer of observers) {
-						observer.world.observersToUpdate.push([entityId, observer]);
-					}
-
-					// TODO: This currently does not support nested fields.
-
-					// eslint-disable-next-line roblox-ts/no-array-pairs
-					for (const [key, value] of pairs(data)) {
-						componentData[key as never][entityId as never] = value as never;
-					}
-				},
+		return Sift.Dictionary.merge<[T, ComponentInternalFields<T>]>(componentData, {
+			componentId: getNextComponentId(),
+			componentType: ComponentType.Component,
+			observers: observers,
+			setDefaults: undefined,
+			/**
+			 * Clones all the data from one entity to another. This will
+			 * overwrite any existing data for the target entity. If you want
+			 * to copy specific properties, then you should do this manually.
+			 *
+			 * @param fromEntityId The entity to copy from.
+			 * @param toEntityId The entity to copy to.
+			 */
+			clone(fromEntityId: EntityId, toEntityId: EntityId): void {
+				// eslint-disable-next-line roblox-ts/no-array-pairs
+				for (const [key] of pairs(componentData as ComponentData)) {
+					componentData[key][toEntityId] = componentData[key][fromEntityId];
+				}
 			},
-		) as unknown as ComponentInternal<T>;
+
+			/**
+			 * Resets the data for the given entity to the default values if
+			 * they are defined.
+			 *
+			 * @param entityId The entity to reset.
+			 */
+			reset(entityId: EntityId): void {
+				if (this.setDefaults === undefined) {
+					return;
+				}
+
+				const data = this.setDefaults();
+
+				// eslint-disable-next-line roblox-ts/no-array-pairs
+				for (const [key] of pairs(componentData as ComponentData)) {
+					componentData[key][entityId] = data[key];
+				}
+			},
+
+			/**
+			 * Sets the data for the given entity.
+			 *
+			 * The set function is used to update any observers that are
+			 * watching the given component. If there are no observers, then it
+			 * is recommended to use the component data directly.
+			 *
+			 * There is no equality check, so it is recommended to only use this
+			 * function when the data has changed.
+			 *
+			 * @param entityId The entity to update.
+			 * @param data The data to update.
+			 */
+			set(entityId: EntityId, data: PartialComponentToKeys<T>): void {
+				for (const observer of observers) {
+					observer.world.observersToUpdate.push([entityId, observer]);
+				}
+
+				for (const [key, value] of pairs(data as ComponentData)) {
+					componentData[key][entityId] = value;
+				}
+			},
+		}) as ComponentInternal<T>;
 	}
 
 	/**
@@ -252,9 +237,12 @@ export namespace ComponentInternalCreation {
 	export function createTag(): TagComponent {
 		componentInstantiationCheck();
 
-		return {
+		const tag: TagComponentInternal = {
 			componentId: getNextComponentId(),
-		} as TagComponentInternal;
+			componentType: ComponentType.Tag,
+		};
+
+		return tag as TagComponent;
 	}
 
 	/**
@@ -269,12 +257,12 @@ export namespace ComponentInternalCreation {
 	 *
 	 * @returns A flyweight component.
 	 */
-	export function createFlyweight<T extends object>(schema: T): Flyweight<T> {
+	export function createFlyweight<T extends FlyweightData>(schema: T): Flyweight<T> {
 		componentInstantiationCheck();
 
-		const flyweight = Sift.Dictionary.merge(schema, {
+		const flyweight = Sift.Dictionary.merge<[T, FlyweightInternalFields<T>]>(schema, {
 			componentId: getNextComponentId(),
-
+			componentType: ComponentType.Flyweight,
 			/**
 			 * Sets the data for the flyweight.
 			 *
@@ -284,10 +272,10 @@ export namespace ComponentInternalCreation {
 			 *
 			 * @param data The data to update.
 			 */
-			set<U extends Partial<T>>(data: U): void {
+			set(data: Partial<T>): void {
 				// eslint-disable-next-line roblox-ts/no-array-pairs
-				for (const [key, value] of pairs(data)) {
-					flyweight[key as never] = value as never;
+				for (const [key, value] of pairs(data as FlyweightData)) {
+					(flyweight as FlyweightData)[key] = value;
 				}
 			},
 		}) as FlyweightInternal<T>;
@@ -300,34 +288,22 @@ export namespace ComponentInternalCreation {
  * Creates an array of the given size, and fills it with the given default
  * value.
  *
- * @param defaultValue The default value to fill the array with.
+ * @param componentData The default value to fill the array with.
  * @param arraySize The size of the array to create (the total number of
  * allowed entities).
  *
  * @returns The pre-allocated array.
  */
-function createComponentArray<T extends Tree<Type>>(
-	defaultValue: T,
-	arraySize: number,
-): ComponentArray<T> {
-	if (typeOf(defaultValue) === "function") {
-		return new (defaultValue as ArrayConstructor)(arraySize) as ComponentArray<T>;
-	}
+function createComponentArray<T extends ComponentData>(componentData: T, arraySize: number): T {
+	const result: ComponentData = {};
 
-	if (t.array(t.any)(defaultValue) === true) {
-		if ((defaultValue as Array<T>).size() > 0) {
-			return new Array<T>(arraySize, (defaultValue as Array<T>)[0]) as ComponentArray<T>;
+	for (const [key, value] of pairs(componentData as ComponentData)) {
+		if (!t.array(t.any)(value)) {
+			throw `Invalid component data key: ${key}`;
 		}
 
-		return new Array<T>(arraySize) as ComponentArray<T>;
+		result[key] = new Array<typeof value>(arraySize);
 	}
 
-	const result: ComponentArray = {};
-
-	for (const [key, value] of pairs(defaultValue as Record<keyof typeof ComponentTypes, T>)) {
-		// TODO: key should be the user-defined object key
-		result[key] = createComponentArray(value, arraySize);
-	}
-
-	return result as never;
+	return result as T;
 }

--- a/src/lib/ecs/entity-manager.ts
+++ b/src/lib/ecs/entity-manager.ts
@@ -121,7 +121,7 @@ export class EntityManager {
 	}
 
 	/** @hidden */
-	public updatePending(denseArray: Array<number>): void {
+	public updatePending(denseArray: Array<EntityId>): void {
 		for (const entityId of denseArray) {
 			if (!this.alive(entityId)) {
 				return;

--- a/src/lib/ecs/observer.spec.ts
+++ b/src/lib/ecs/observer.spec.ts
@@ -33,13 +33,13 @@ export = (): void => {
 
 			for (const _ of observer.iter()) {
 				calledFn.push(1);
-			};
+			}
 
 			component.set(id, { x: 1 });
 
 			for (const _ of observer.iter()) {
 				calledFn.push(2);
-			};
+			}
 
 			expect(shallowEquals(calledFn, [])).to.equal(true);
 
@@ -47,7 +47,7 @@ export = (): void => {
 
 			for (const _ of observer.iter()) {
 				calledFn.push(3);
-			};
+			}
 
 			expect(shallowEquals(calledFn, [3])).to.equal(true);
 		});
@@ -58,11 +58,11 @@ export = (): void => {
 			const component = ComponentInternalCreation.createComponent({
 				x: ComponentTypes.Number,
 			});
-	
+
 			const component2 = ComponentInternalCreation.createComponent({
 				y: ComponentTypes.Number,
 			});
-	
+
 			const observer = world.createObserver(component).with(component2);
 
 			const id = world.add();
@@ -79,9 +79,9 @@ export = (): void => {
 
 			for (const entityId of observer.iter()) {
 				calledFn.push(entityId);
-			};
+			}
 
 			expect(shallowEquals(calledFn, [id2])).to.equal(true);
 		});
-	});	
+	});
 };

--- a/src/lib/ecs/observer.ts
+++ b/src/lib/ecs/observer.ts
@@ -1,6 +1,6 @@
-import { EntityId } from "../types/ecs";
+import { AllComponentTypes, AnyComponent, AnyFlyweight, EntityId } from "../types/ecs";
 import { SparseSet } from "./collections/sparse-set";
-import { AllComponentTypes, AnyComponent, AnyComponentInternal } from "./component";
+import { Internal } from "./component";
 import { World } from "./world";
 
 /**
@@ -29,7 +29,7 @@ export class Observer {
 	public readonly world: World;
 
 	/** The primary component that the observer is watching. */
-	public primaryComponent: AllComponentTypes;
+	public primaryComponent: AnyComponent | AnyFlyweight;
 	/**
 	 * A cache of all entities that match the observer.
 	 *
@@ -41,10 +41,10 @@ export class Observer {
 	 */
 	public storage: SparseSet = new SparseSet();
 
-	constructor(world: World, component: AllComponentTypes) {
+	constructor(world: World, component: AnyComponent | AnyFlyweight) {
 		this.world = world;
 		this.primaryComponent = component;
-		(component as AnyComponentInternal).observers.push(this);
+		(component as Internal<AnyComponent>).observers.push(this);
 	}
 
 	/**

--- a/src/lib/ecs/query.spec.ts
+++ b/src/lib/ecs/query.spec.ts
@@ -222,7 +222,6 @@ export = (): void => {
 				});
 
 				const id1 = tempWorld.add();
-				const id2 = tempWorld.add();
 
 				tempWorld.addComponent(id1, component);
 

--- a/src/lib/ecs/world.ts
+++ b/src/lib/ecs/world.ts
@@ -2,20 +2,22 @@ import { HttpService } from "@rbxts/services";
 
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 import Tina from "../..";
-import { ComponentId, EntityId } from "../types/ecs";
-import { slice } from "../util/array-utils";
-import { Archetype } from "./collections/archetype";
-import { SparseSet } from "./collections/sparse-set";
 import {
 	AllComponentTypes,
 	AnyComponent,
-	AnyComponentInternal,
 	AnyFlyweight,
-	// eslint-disable-next-line @typescript-eslint/no-unused-vars
-	GetComponentSchema,
-	OptionalKeys,
+	Component,
+	ComponentData,
+	ComponentId,
+	EntityId,
+	FlyweightData,
+	PartialComponentToKeys,
 	TagComponent,
-} from "./component";
+} from "../types/ecs";
+import { slice } from "../util/array-utils";
+import { Archetype } from "./collections/archetype";
+import { SparseSet } from "./collections/sparse-set";
+import { ComponentBitmask, ComponentType, Internal } from "./component";
 import { EntityManager } from "./entity-manager";
 import { Observer } from "./observer";
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
@@ -65,6 +67,16 @@ export class World {
 	/** The world options that were passed to the constructor. */
 	public readonly options: WorldOptions;
 
+	/**
+	 * Entities that have been queued to have their component data removed from this frame.
+	 * @hidden
+	 */
+	public componentDataToRemoveLater: Array<[EntityId, Internal<AllComponentTypes>]> = [];
+	/**
+	 * Entities that have been queued to have their component data removed from last frame.
+	 * @hidden
+	 */
+	public componentDataToRemoveNow: Array<[EntityId, Internal<AllComponentTypes>]> = [];
 	/** A unique identifier for the world. */
 	public id = HttpService.GenerateGUID(false);
 	/**
@@ -103,16 +115,19 @@ export class World {
 	 *
 	 * @returns The world instance to allow for method chaining.
 	 */
-	public addComponent<C extends AnyComponent>(
+	public addComponent<T extends ComponentData>(
 		entityId: EntityId,
-		component: C,
-		data?: Partial<OptionalKeys<GetComponentSchema<C>>>,
+		component: Component<T>,
+		data?: PartialComponentToKeys<T>,
 	): this;
-	public addComponent(entityId: EntityId, component: AnyFlyweight): this;
-	public addComponent<C extends AnyComponent>(
+	public addComponent<T extends FlyweightData>(
 		entityId: EntityId,
-		component: C,
-		data?: Partial<OptionalKeys<GetComponentSchema<C>>>,
+		component: AnyFlyweight<T>,
+	): this;
+	public addComponent<T extends ComponentData>(
+		entityId: EntityId,
+		component: Component<T>,
+		data?: PartialComponentToKeys<T>,
 	): this {
 		if (!this.has(entityId)) {
 			throw `Entity ${entityId} does not exist in world ${tostring(this)}`;
@@ -122,7 +137,7 @@ export class World {
 
 		debug.profilebegin("World:addComponent");
 		{
-			const componentId = (component as AnyComponentInternal).componentId;
+			const componentId = (component as Internal<Component<T>>).componentId;
 			if (
 				!this.hasComponentInternal(this.entityManager.updateTo[entityId].mask, componentId)
 			) {
@@ -150,7 +165,7 @@ export class World {
 	 *
 	 * @returns The world instance to allow for method chaining.
 	 */
-	public addTag<C extends TagComponent>(entityId: EntityId, tag: C): this {
+	public addTag(entityId: EntityId, tag: TagComponent): this {
 		return this.addComponent(entityId, tag as unknown as AnyComponent);
 	}
 
@@ -169,7 +184,7 @@ export class World {
 	 *
 	 * @returns The newly created observer.
 	 */
-	public createObserver<C extends AnyComponent>(component: C): Observer {
+	public createObserver(component: AnyComponent | AnyFlyweight): Observer {
 		const observer = new Observer(this, component);
 		this.observers.set(component, observer);
 
@@ -227,6 +242,39 @@ export class World {
 		}
 
 		this.flush();
+	}
+
+	/**
+	 * Disables a component on an entity.
+	 *
+	 * This will keep the component on the entity, but will prevent it from
+	 * being matched by queries. This is useful when you wish to preserve the
+	 * state of a component.
+	 *
+	 * @param entityId The id of the entity to disable the component on.
+	 * @param component The component to disable.
+	 *
+	 * @returns The world instance to allow for method chaining.
+	 */
+	public disableComponent(entityId: EntityId, component: AllComponentTypes): this {
+		if (!this.has(entityId)) {
+			throw `Entity ${entityId} does not exist in world ${tostring(this)}`;
+		}
+
+		this.componentsToUpdate.add(entityId);
+
+		debug.profilebegin("World:disableComponent");
+		{
+			const componentId: number = (component as Internal<AllComponentTypes>).componentId;
+			if (
+				this.hasComponentInternal(this.entityManager.updateTo[entityId].mask, componentId)
+			) {
+				this.updateArchetype(entityId, componentId);
+			}
+		}
+		debug.profileend();
+
+		return this;
 	}
 
 	/**
@@ -341,7 +389,7 @@ export class World {
 	 * @returns true if the entity has the given component.
 	 */
 	public hasComponent(entityId: EntityId, component: AnyComponent | AnyFlyweight): boolean {
-		const componentId = (component as AnyComponentInternal).componentId;
+		const componentId = (component as Internal<AllComponentTypes>).componentId;
 		return this.hasComponentInternal(this.entityManager.entities[entityId].mask, componentId);
 	}
 
@@ -353,9 +401,9 @@ export class World {
 	 *
 	 * @returns true if the entity has none of the given components.
 	 */
-	public hasNoneOf(entityId: EntityId, ...components: Array<AnyComponent>): boolean {
+	public hasNoneOf(entityId: EntityId, ...components: Array<AllComponentTypes>): boolean {
 		for (const component of components) {
-			if (this.hasComponent(entityId, component)) {
+			if (this.hasComponent(entityId, component as AnyComponent)) {
 				return false;
 			}
 		}
@@ -371,7 +419,7 @@ export class World {
 	 *
 	 * @returns True if the entity has the tag.
 	 */
-	public hasTag<C extends TagComponent>(entityId: EntityId, tag: C): boolean {
+	public hasTag(entityId: EntityId, tag: TagComponent): boolean {
 		return this.hasComponent(entityId, tag as unknown as AnyComponent);
 	}
 
@@ -417,22 +465,15 @@ export class World {
 	 * @returns The world instance to allow for method chaining.
 	 */
 	public removeComponent(entityId: EntityId, component: AnyComponent | AnyFlyweight): this {
-		if (!this.has(entityId)) {
-			throw `Entity ${entityId} does not exist in world ${tostring(this)}`;
-		}
+		this.disableComponent(entityId, component);
 
-		this.componentsToUpdate.add(entityId);
-
-		debug.profilebegin("World:removeComponent");
-		{
-			const componentId = (component as AnyComponentInternal).componentId;
-			if (
-				this.hasComponentInternal(this.entityManager.updateTo[entityId].mask, componentId)
-			) {
-				this.updateArchetype(entityId, componentId);
-			}
+		if ((component as Internal<AllComponentTypes>).componentType !== ComponentType.Component) {
+			// Component is a Flyweight
+			return this;
 		}
-		debug.profileend();
+		// schedule data to be removed somewhere else
+
+		this.componentDataToRemoveLater.push([entityId, component as Internal<AllComponentTypes>]);
 
 		return this;
 	}
@@ -465,8 +506,8 @@ export class World {
 	 *
 	 * @returns The world instance to allow for method chaining.
 	 */
-	public removeTag<C extends TagComponent>(entityId: EntityId, tag: C): this {
-		return this.removeComponent(entityId, tag as unknown as AnyComponent);
+	public removeTag(entityId: EntityId, tag: TagComponent): this {
+		return this.disableComponent(entityId, tag);
 	}
 
 	/**
@@ -603,7 +644,7 @@ export class World {
 	 *
 	 * @returns The archetype with the given mask.
 	 */
-	private getArchetype(mask: Array<ComponentId>): Archetype {
+	private getArchetype(mask: ComponentBitmask): Archetype {
 		const hash = mask.join(",");
 		if (!this.entityManager.archetypes.has(hash)) {
 			const arch = new Archetype(slice(mask));
@@ -628,7 +669,7 @@ export class World {
 	 *
 	 * @returns Whether or not the entity has the given component.
 	 */
-	private hasComponentInternal(mask: Array<ComponentId>, componentId: number): boolean {
+	private hasComponentInternal(mask: ComponentBitmask, componentId: ComponentId): boolean {
 		return (mask[~~(componentId / 32)] & (1 << componentId % 32)) >= 1;
 	}
 
@@ -672,7 +713,7 @@ export class World {
 	 */
 	private updatePendingComponents(): void {
 		this.entityManager.updatePending(this.componentsToUpdate.dense);
-		this.componentsToUpdate.dense = [];
+		this.componentsToUpdate.dense.clear();
 	}
 
 	/**

--- a/src/lib/types/ecs.d.ts
+++ b/src/lib/types/ecs.d.ts
@@ -1,2 +1,32 @@
+import { ComponentMethods, FlyweightMethods } from "../ecs/component";
+import { Immutable } from "./readonly";
+
 export type EntityId = number;
 export type ComponentId = number;
+
+export declare type PartialComponentToKeys<T extends ComponentData> = {
+	[K in keyof T]?: T[K][EntityId];
+};
+
+export declare type GetComponentSchema<C> = C extends Component<infer T> ? T : never;
+
+export declare type AllComponentTypes<T = unknown> =
+	| AnyComponent<T>
+	| AnyFlyweight<T>
+	| TagComponent;
+
+export declare type ComponentData = Record<string, Array<unknown>>;
+export declare type FlyweightData = Record<string, unknown>;
+
+export declare type Component<T extends ComponentData> = T & ComponentMethods<T>;
+export declare type Flyweight<T extends FlyweightData> = Immutable<T> & FlyweightMethods<T>;
+export declare type TagComponent = object & {
+	[index: string]: never;
+};
+
+export declare type AnyComponent<T = unknown> = T extends ComponentData
+	? Component<T>
+	: Component<{}>;
+export declare type AnyFlyweight<T = unknown> = T extends FlyweightData
+	? Flyweight<T>
+	: Flyweight<{}>;


### PR DESCRIPTION
Changes the component types from the old recursive `Tree<Type>` to a new Record type. 

Although we lose the ability to express our components in a certain way, our component functions (such as set) did not currently respect the old format and would have not worked on recursive types regardless. The two options were to either fix these functions, but add overhead to our methods, or to remove them - which we opted for since we were never using them in this regard anyway.