### PR TITLE
fix(ecs) observers not being cleared

### DIFF
--- a/src/lib/ecs/world.ts
+++ b/src/lib/ecs/world.ts
@@ -726,5 +726,7 @@ export class World {
 		for (const [entityId, observer] of this.observersToUpdate) {
 			observer.storage.add(entityId);
 		}
+
+		this.observersToUpdate = [];
 	}
 }


### PR DESCRIPTION
##### Description

Observers were not being cleared, therefore the entities if they ever matched an observer once would match to the observers every frame forever.